### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Lighthead-RCNN-Pytorch
     - Python 3.6 (Conda Environment has been used)
     - Cuda 9.0
     - GCC 5 (GCC 6 does not work)
+    - GPU Tesla K80
 
 - What will not work?
     - I tried Python3.5, Python3.7 and Python2.7. None of these python versions worked for me.

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ I have only trained it with 18 epochs instead of 30 epochs in the original paper
 
 2. #### Prepare COCO dataset.
 
-1. It is recommended to symlink the dataset root to `$Lighthead-RCNN-Pytorch/data`.
+- It is recommended to symlink the dataset root to `$Lighthead-RCNN-Pytorch/data`.
 
-2. Create following folders and download the [pretrained model](https://drive.google.com/file/d/10Ku_G2FABjtEjWp3XWVmuguPkpbaTGV4/view?usp=sharing) to work_space/final
+- Create following folders and download the [pretrained model](https://drive.google.com/file/d/10Ku_G2FABjtEjWp3XWVmuguPkpbaTGV4/view?usp=sharing) to work_space/final
 
-3. From the main Lighthead-RCNN-in-Pytorch0.4.1 directory run the script [download_coco_data.sh](scripts/download_coco_data.sh) to download and extract the coco dataset.
+- From the main Lighthead-RCNN-in-Pytorch0.4.1 directory run the script [download_coco_data.sh](scripts/download_coco_data.sh) to download and extract the coco dataset.
 
 ```shell
 Lighthead-RCNN-Pytorch

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ I have only trained it with 18 epochs instead of 30 epochs in the original paper
 
 3. #### Create following folders and download the [pretrained model](https://drive.google.com/file/d/10Ku_G2FABjtEjWp3XWVmuguPkpbaTGV4/view?usp=sharing) to work_space/final
 
+4. From the main Lighthead-RCNN-in-Pytorch0.4.1 directory run the script [download_coco_data.sh](scripts/download_coco_data.sh) to download and extract the coco dataset.
+
 ```shell
 Lighthead-RCNN-Pytorch
 ├── functions
@@ -72,6 +74,7 @@ Lighthead-RCNN-Pytorch
 │   ├── final
 │   ├── save
 ```
+
 
 ### Installation 
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ I have only trained it with 18 epochs instead of 30 epochs in the original paper
 
 2. #### Prepare COCO dataset.
 
-   It is recommended to symlink the dataset root to `$Lighthead-RCNN-Pytorch/data`.
+1. It is recommended to symlink the dataset root to `$Lighthead-RCNN-Pytorch/data`.
 
-3. #### Create following folders and download the [pretrained model](https://drive.google.com/file/d/10Ku_G2FABjtEjWp3XWVmuguPkpbaTGV4/view?usp=sharing) to work_space/final
+2. Create following folders and download the [pretrained model](https://drive.google.com/file/d/10Ku_G2FABjtEjWp3XWVmuguPkpbaTGV4/view?usp=sharing) to work_space/final
 
-4. From the main Lighthead-RCNN-in-Pytorch0.4.1 directory run the script [download_coco_data.sh](scripts/download_coco_data.sh) to download and extract the coco dataset.
+3. From the main Lighthead-RCNN-in-Pytorch0.4.1 directory run the script [download_coco_data.sh](scripts/download_coco_data.sh) to download and extract the coco dataset.
 
 ```shell
 Lighthead-RCNN-Pytorch
@@ -66,8 +66,7 @@ Lighthead-RCNN-Pytorch
 ├── data
 │   ├── coco2014
 │   │   ├── annotations
-│   │   ├── train2014
-│   │   ├── val2014
+│   │   ├── images
 ├── work_space
 │   ├── model
 │   ├── log
@@ -77,6 +76,16 @@ Lighthead-RCNN-Pytorch
 
 
 ### Installation 
+- Following configurations are tested
+    - Ubuntu 16.04 LTS
+    - Python 3.6 (Conda Environment has been used)
+    - Cuda 9.0
+    - GCC 5 (GCC 6 does not work)
+
+- What will not work?
+    - I tried Python3.5, Python3.7 and Python2.7. None of these python versions worked for me.
+    - GCC 6 (On Debian, GCC 5 is not officially supported. So you may need to shift to Ubuntu. There will be workaround though that I didn't explore)
+
 
 1. Install PyTorch 0.4.1 and torchvision following the [official instructions](https://pytorch.org/).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy
+opencv-python
 Cython==0.29
 torchvision==0.2.1
 setuptools==20.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,12 @@
+numpy
+Cython==0.29
 torchvision==0.2.1
 setuptools==20.7.0
-numpy==1.11.0
 six==1.10.0
-Cython==0.29
 Pillow==5.3.0
 chainer==5.0.0
 chainercv==0.11.0
 matplotlib==3.0.2
-model==0.6.0
 pycocotools==2.0.0
 tensorboardX==1.4
 torch==0.4.1.post2

--- a/scripts/download_coco_data.sh
+++ b/scripts/download_coco_data.sh
@@ -1,0 +1,34 @@
+cd data
+mkdir coco2014
+cd coco2014
+mkdir images
+cd images
+
+wget http://images.cocodataset.org/zips/train2014.zip
+wget http://images.cocodataset.org/zips/val2014.zip
+wget http://images.cocodataset.org/zips/train2017.zip
+wget http://images.cocodataset.org/zips/val2017.zip
+
+unzip train2014.zip
+unzip val2014.zip
+unzip train2017.zip
+unzip val2017.zip
+
+rm train2014.zip
+rm val2014.zip
+rm train2017.zip
+rm val2017.zip
+
+cd ../
+wget http://images.cocodataset.org/annotations/annotations_trainval2014.zip
+wget http://images.cocodataset.org/annotations/annotations_trainval2017.zip
+wget https://dl.fbaipublicfiles.com/detectron/coco/coco_annotations_minival.tgz
+
+unzip annotations_trainval2014.zip
+unzip annotations_trainval2017.zip
+tar -xvf coco_annotations_minival.tgz
+
+cd ../
+rm annotations_trainval2014.zip
+rm annotations_trainval2017.zip
+rm coco_annotations_minival.tgz

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -22,7 +22,8 @@ class coco_dataset(Dataset):
         else:
             self.training = False
             self.orig_dataset = COCOBboxDataset(data_dir=conf.coco_path, 
-                                                split='minival', 
+                                                split='minival',
+                                                year='2014',
                                                 use_crowded=True, 
                                                 return_crowded=True, 
                                                 return_area=True)


### PR DESCRIPTION
- Fixes the validation of the model on coco minival dataset
- Adds a script to download coco dataset
- Adds info in README about which environment works and which does not
- Updates `requirements.txt` to work seamlessly. Numpy and Cython should be installed first otherwise you will get the error.
- Fixes https://github.com/TreB1eN/Lighthead-RCNN-in-Pytorch0.4.1/issues/6

Thanks